### PR TITLE
add custom run task to gradle script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Default jar output path is: `build/libs/*.jar`
 **Note:** if builds begin failing because unit tests get a 403 error, use `./gradlew -x test build`
 
 ## Running the program
+Use gradle to run the program:
+
+    ./gradlew run
+
 #### Linux
 Double click the .jar file to run the program. If this does not work, you may need to make the file executable:
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,3 +51,10 @@ jar {
                    "Main-Class": "net.localarea.doug.tempcon.Main")
     }
 }
+
+task run(type: JavaExec, dependsOn: jar) {
+    group = 'application'
+    description = 'Run the application'
+    classpath = files(jar.archiveFile)
+    main = 'net.localarea.doug.tempcon.Main'
+}


### PR DESCRIPTION
Enables `./gradlew run` to build and launch the application.